### PR TITLE
Fix missing CORS header on services API response

### DIFF
--- a/src/pages/api/services.ts
+++ b/src/pages/api/services.ts
@@ -9,6 +9,7 @@ export const GET: APIRoute = async () => {
     status: 200,
     headers: {
       "Content-Type": "application/json; charset=utf-8",
+      "Access-Control-Allow-Origin": "*",
       "Cache-Control": "public, max-age=600", // 10 min
     },
   });


### PR DESCRIPTION
## Summary
- add the Access-Control-Allow-Origin header to the /api/services GET response so clients can consume it cross-origin

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd7e56fae48327a7859f5639898ced