### PR TITLE
Revamp home page hero and marketing sections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,12 @@
         "html-validate": "^10.0.0",
         "postcss": "^8.4.40",
         "prettier": "^3.3.3",
+        "rimraf": "^6.0.1",
         "tailwindcss": "^3.4.10",
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": ">=20.0.0 <23.0.0"
+        "node": "22.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7769,6 +7770,66 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -13,7 +13,7 @@ const { pathname } = Astro.url;
 <header class="site-header sticky top-0 z-50 bg-zinc-900 text-white border-b border-white/10">
   <div class="container-max flex items-center justify-between h-16 pr-6 md:pr-10">
     <a href="/" class="flex items-center gap-2 no-underline">
-      <img src="/logo/ecoquimia.svg" alt="Ecoquimia" class="h-6 w-auto" loading="eager" />
+      <img src="/logo/logo.svg" alt="Ecoquimia" class="h-6 w-auto" loading="eager" />
     </a>
 
     <nav class="flex items-center gap-6">

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,140 @@
+---
+interface CTA {
+  label: string;
+  href: string;
+  variant?: "primary" | "secondary" | "outline" | "ghost";
+  prefetch?: true | "load" | "visible";
+  target?: string;
+  rel?: string;
+  icon?: string;
+}
+
+interface Stat {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  id?: string;
+  eyebrow?: string;
+  title: string;
+  highlight?: string;
+  description?: string;
+  backgroundImage: string;
+  backgroundAlt: string;
+  overlayOpacity?: number;
+  primaryCta?: CTA;
+  secondaryCta?: CTA;
+  tertiaryCta?: CTA;
+  bullets?: string[];
+  stats?: Stat[];
+}
+
+const {
+  id = "hero",
+  eyebrow,
+  title,
+  highlight,
+  description,
+  backgroundImage,
+  backgroundAlt,
+  overlayOpacity = 0.45,
+  primaryCta,
+  secondaryCta,
+  tertiaryCta,
+  bullets = [],
+  stats = [],
+} = Astro.props as Props;
+
+const ctas = [primaryCta, secondaryCta, tertiaryCta].filter(Boolean) as CTA[];
+
+const variantClasses = {
+  primary: "btn btn-primary",
+  secondary: "btn btn-secondary",
+  outline: "btn btn-outline",
+  ghost: "btn btn-ghost",
+} as const;
+
+const getVariantClass = (variant: CTA["variant"]) => variantClasses[variant ?? "primary"];
+---
+<section id={id} class="relative isolate overflow-hidden">
+  <picture class="absolute inset-0 -z-20">
+    <img
+      src={backgroundImage}
+      alt={backgroundAlt}
+      class="h-full w-full object-cover"
+      loading="eager"
+      fetchpriority="high"
+    />
+  </picture>
+
+  <div
+    class="absolute inset-0 -z-10 bg-gradient-to-b from-black/80 via-black/65 to-black/70"
+    style={`opacity: ${overlayOpacity}`}
+  ></div>
+
+  <div class="container-max relative py-24 md:py-32 text-white">
+    <div class="max-w-3xl">
+      {eyebrow && (
+        <span class="inline-flex items-center rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.2em] text-white/80">
+          {eyebrow}
+        </span>
+      )}
+
+      <h1 class="mt-5 text-4xl md:text-6xl font-bold leading-tight drop-shadow-md">
+        {title}
+        {highlight && <span class="block text-emerald-300">{highlight}</span>}
+      </h1>
+
+      {description && <p class="mt-5 max-w-2xl text-lg text-white/90">{description}</p>}
+
+      {ctas.length > 0 && (
+        <div class="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
+          {ctas.map((cta) => {
+            const attrs = cta.prefetch
+              ? { "data-astro-prefetch": cta.prefetch === true ? "" : cta.prefetch }
+              : {};
+            return (
+              <a
+                href={cta.href}
+                class={`${getVariantClass(cta.variant)} btn-block`}
+                target={cta.target}
+                rel={cta.rel}
+                {...attrs}
+              >
+                {cta.icon && <span aria-hidden="true">{cta.icon}</span>}
+                <span>{cta.label}</span>
+              </a>
+            );
+          })}
+        </div>
+      )}
+
+      {bullets.length > 0 && (
+        <ul class="mt-6 grid gap-2 text-sm text-white/80 sm:grid-cols-2">
+          {bullets.map((bullet) => (
+            <li class="flex items-center gap-2">
+              <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/20 text-emerald-200">
+                ✓
+              </span>
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+
+    {stats.length > 0 && (
+      <dl class="mt-12 grid gap-6 sm:grid-cols-3">
+        {stats.map((stat) => (
+          <div class="rounded-2xl border border-white/10 bg-white/5 px-6 py-5 text-center backdrop-blur">
+            <dt class="text-sm uppercase tracking-wider text-white/70">{stat.label}</dt>
+            <dd class="mt-2 text-3xl font-semibold text-white">{stat.value}</dd>
+          </div>
+        ))}
+      </dl>
+    )}
+  </div>
+
+  <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 bottom-0 h-28 bg-gradient-to-b from-transparent to-white"></div>
+</section>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -6,10 +6,19 @@ interface Props {
   title?: string;
   description?: string;
 }
-const { title = "Ecoquimia", description = "Control de plagas en RD" } = Astro.props as Props;
+
+const {
+  title = "Ecoquimia",
+  description = "Control de plagas en RD",
+} = Astro.props as Props;
 
 const hasHeader = Astro.slots.has("header");
 const hasFooter = Astro.slots.has("footer");
+const hasHead = Astro.slots.has("head");
+
+const canonicalUrl = Astro.site
+  ? new URL(Astro.url.pathname, Astro.site).toString()
+  : `${Astro.url.origin}${Astro.url.pathname}`;
 ---
 <!doctype html>
 <html lang="es">
@@ -18,10 +27,28 @@ const hasFooter = Astro.slots.has("footer");
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <meta name="description" content={description} />
     <title>{title}</title>
+    <link rel="canonical" href={canonicalUrl} />
+    <link rel="icon" type="image/svg+xml" href="/logo/logo.svg" />
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    {hasHead && <slot name="head" />}
   </head>
-  <body class="page-light">
+  <body class="page-light bg-white text-zinc-900 antialiased">
+    <a
+      href="#contenido-principal"
+      class="fixed left-4 top-4 z-[999] -translate-y-32 rounded-full bg-emerald-600 px-5 py-3 text-sm font-semibold text-white shadow-lg transition focus:translate-y-0 focus:outline-none"
+    >
+      Saltar al contenido
+    </a>
     {hasHeader ? <slot name="header" /> : <Header />}
-    <main><slot /></main>
+    <main id="contenido-principal" class="min-h-[60vh]">
+      <slot />
+    </main>
     {hasFooter ? <slot name="footer" /> : <Footer />}
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,76 +4,222 @@ import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import { services } from "../data/services";
 import ServiceCard from "../components/ServiceCard.astro";
+import Hero from "../components/Hero.astro";
 
 export const prerender = true;
+
+const benefits = [
+  {
+    title: "Protocolos certificados",
+    description: "Aplicamos productos avalados por Salud Pública y fichas técnicas actualizadas.",
+    icon: "🧪",
+  },
+  {
+    title: "Monitoreo continuo",
+    description: "Seguimiento digital de cada visita para que sepas qué, cuándo y dónde intervenimos.",
+    icon: "📊",
+  },
+  {
+    title: "Planes a medida",
+    description: "Diseñamos programas residenciales y comerciales alineados a tus auditorías.",
+    icon: "🛡️",
+  },
+];
+
+const sectors = [
+  {
+    title: "Residencial",
+    description: "Casas, torres y condominios protegidos con tratamientos amigables con mascotas.",
+    icon: "🏠",
+  },
+  {
+    title: "Comercial",
+    description: "Restaurantes, hoteles y comercios con planes de respuesta 24/7.",
+    icon: "🏢",
+  },
+  {
+    title: "Industrial",
+    description: "Plantas, almacenes y laboratorios con bitácoras para auditorías externas.",
+    icon: "🏭",
+  },
+];
+
+const process = [
+  {
+    title: "Diagnóstico completo",
+    description: "Inspeccionamos cada área clave, identificamos plagas y puntos críticos de acceso.",
+    number: "01",
+  },
+  {
+    title: "Plan de acción",
+    description: "Definimos tratamientos, frecuencia y productos ideales para tu operación.",
+    number: "02",
+  },
+  {
+    title: "Seguimiento y reporte",
+    description: "Monitoreamos resultados, ajustamos cuando es necesario y enviamos reportes claros.",
+    number: "03",
+  },
+];
 ---
 
-<Base title="Ecoquimia | Control de Plagas" description="Servicios profesionales de fumigación y control de plagas en República Dominicana.">
+<Base
+  title="Ecoquimia | Control de Plagas"
+  description="Servicios profesionales de fumigación y control de plagas en República Dominicana."
+>
   <!-- Header -->
   <Header slot="header" />
 
-  <!-- HERO con imagen de fondo (manteniendo el estilo del primer día) -->
-  <section class="relative overflow-hidden">
-    <!-- Fondo -->
-    <picture class="absolute inset-0 -z-10">
-      <img
-        src="/hero/hero-01.png"
-        alt=""
-        class="h-full w-full object-cover"
-        loading="eager"
-        fetchpriority="high"
-      />
-    </picture>
-
-    <!-- Overlay para legibilidad (similar al día 1, no tapa el resto) -->
-    <div class="absolute inset-0 -z-10 bg-black/35"></div>
-
-    <!-- Contenido del hero -->
-    <div class="container-max py-24 md:py-32 text-white">
-      <span class="inline-flex items-center rounded-full border border-white/25 bg-black/30 px-3 py-1 text-xs">
-        Control Integral de Plagas
-      </span>
-
-      <h1 class="mt-4 text-4xl md:text-6xl font-extrabold leading-tight drop-shadow">
-        Fumigación profesional <span class="text-emerald-300">a otro nivel</span>
-      </h1>
-
-      <p class="mt-4 max-w-2xl text-white/90">
-        Protegemos hogares y negocios contra cucarachas, roedores, termitas y más.
-      </p>
-
-      <div class="mt-6 flex flex-wrap gap-3">
-        <a href="/cotizacion" class="btn btn-primary" data-astro-prefetch="load">Solicitar cotización</a>
-        <a href="/services" class="btn btn-outline" data-astro-prefetch>Ver servicios</a>
-      </div>
-    </div>
-
-    <!-- Fade al blanco para que el bloque siguiente no quede solapado -->
-    <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 bottom-0 h-24 -z-10 bg-gradient-to-b from-transparent to-white"></div>
-  </section>
+  <Hero
+    eyebrow="Control integral de plagas"
+    title="Fumigación profesional"
+    highlight="a otro nivel"
+    description="Protegemos hogares y negocios contra cucarachas, roedores, termitas y más, con procesos auditables y técnicos certificados."
+    backgroundImage="/brief/hero.png"
+    backgroundAlt="Técnico de Ecoquimia aplicando tratamiento profesional de control de plagas"
+    primaryCta={{ label: "Solicitar cotización", href: "/cotizacion", prefetch: "load" }}
+    secondaryCta={{ label: "Ver servicios", href: "/services", variant: "outline", prefetch: true }}
+    tertiaryCta={{
+      label: "WhatsApp inmediato",
+      href: "https://wa.me/18096172105?text=Hola%2C%20quiero%20una%20cotizaci%C3%B3n%20de%20control%20de%20plagas.",
+      variant: "ghost",
+      target: "_blank",
+      rel: "noopener noreferrer",
+    }}
+    bullets={[
+      "Atención en menos de 24 horas",
+      "Productos aprobados por Salud Pública",
+      "Reportes digitales después de cada visita",
+      "Cobertura en Santo Domingo y zonas aledañas",
+    ]}
+    stats={[
+      { value: "+1,500", label: "Intervenciones exitosas" },
+      { value: "24/7", label: "Respuesta ante emergencias" },
+      { value: "15 años", label: "Experiencia en el sector" },
+    ]}
+  />
 
   <!-- NUESTROS SERVICIOS (grilla con cards) -->
   <section class="container-max py-16" aria-labelledby="srv-title">
-    <div class="text-center">
-      <h2 id="srv-title" class="text-2xl md:text-3xl font-bold text-zinc-900">Nuestros servicios</h2>
-      <div class="mx-auto mt-3 h-1.5 w-20 rounded-full bg-brand"></div>
-      <p class="mt-3 text-zinc-600">Planes residenciales y comerciales con certificación.</p>
+    <div class="mx-auto max-w-2xl text-center">
+      <h2 id="srv-title" class="text-3xl font-semibold text-zinc-900 md:text-4xl">Nuestros servicios</h2>
+      <p class="mt-4 text-lg text-zinc-600">
+        Planes residenciales, comerciales e industriales con garantía escrita, fichas técnicas y seguimiento post-servicio.
+      </p>
     </div>
 
-    <div class="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
       {services.map((s) => <ServiceCard service={s} />)}
     </div>
   </section>
 
+  <!-- Beneficios principales -->
+  <section class="bg-emerald-50/60 py-16" aria-labelledby="beneficios-title">
+    <div class="container-max grid gap-12 lg:grid-cols-[1fr,1.2fr] lg:items-center">
+      <div>
+        <p class="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-600">¿Por qué Ecoquimia?</p>
+        <h2 id="beneficios-title" class="mt-4 text-3xl font-semibold text-zinc-900 md:text-4xl">
+          Expertos locales con procesos transparentes
+        </h2>
+        <p class="mt-4 text-lg text-zinc-700">
+          Gestionamos el control de plagas de manera integral: diagnóstico, tratamiento, seguimiento y educación.
+          Nos involucramos para que tu familia o tu negocio estén protegidos todo el año.
+        </p>
+      </div>
+
+      <div class="grid gap-6 sm:grid-cols-2">
+        {benefits.map((benefit) => (
+          <article class="h-full rounded-3xl border border-emerald-200 bg-white/70 p-6 shadow-sm">
+            <div class="text-3xl" aria-hidden="true">{benefit.icon}</div>
+            <h3 class="mt-4 text-xl font-semibold text-zinc-900">{benefit.title}</h3>
+            <p class="mt-2 text-sm text-zinc-700">{benefit.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Sectores -->
+  <section class="container-max py-16" aria-labelledby="sectores-title">
+    <div class="grid gap-10 lg:grid-cols-[1.2fr,1fr] lg:items-center">
+      <div>
+        <h2 id="sectores-title" class="text-3xl font-semibold text-zinc-900 md:text-4xl">
+          Cobertura en todos los sectores clave
+        </h2>
+        <p class="mt-4 text-lg text-zinc-700">
+          Personal capacitado y protocolos diferenciados para cada industria. Desde hogares hasta cadenas
+          multinacionales.
+        </p>
+        <ul class="mt-6 space-y-3 text-sm text-zinc-600">
+          <li class="flex items-start gap-2">
+            <span class="mt-1 h-2 w-2 rounded-full bg-emerald-500"></span>
+            Programas acorde a normativas BPM, HACCP y auditorías internacionales.
+          </li>
+          <li class="flex items-start gap-2">
+            <span class="mt-1 h-2 w-2 rounded-full bg-emerald-500"></span>
+            Técnicos con capacitación constante y equipos de aspersión, nebulización y geles de última generación.
+          </li>
+        </ul>
+      </div>
+
+      <div class="grid gap-6 sm:grid-cols-3">
+        {sectors.map((sector) => (
+          <article class="rounded-3xl border border-zinc-200 bg-white/90 p-5 text-center shadow-sm">
+            <div class="text-3xl" aria-hidden="true">{sector.icon}</div>
+            <h3 class="mt-3 text-lg font-semibold text-zinc-900">{sector.title}</h3>
+            <p class="mt-2 text-sm text-zinc-600">{sector.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <!-- Proceso -->
+  <section class="bg-zinc-950 py-16 text-white" aria-labelledby="proceso-title">
+    <div class="container-max">
+      <div class="max-w-2xl">
+        <h2 id="proceso-title" class="text-3xl font-semibold md:text-4xl">Tu plan de control en 3 pasos</h2>
+        <p class="mt-4 text-base text-white/80">
+          Nos enfocamos en la prevención y la comunicación constante para que siempre tengas claro el estado del servicio.
+        </p>
+      </div>
+
+      <div class="mt-12 grid gap-6 md:grid-cols-3">
+        {process.map((step) => (
+          <article class="flex h-full flex-col rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <span class="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-300">Paso {step.number}</span>
+            <h3 class="mt-4 text-xl font-semibold text-white">{step.title}</h3>
+            <p class="mt-3 text-sm text-white/80">{step.description}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
   <!-- CTA INTERMEDIA / APRENDE -->
-  <section class="container-max pb-16">
-    <div class="rounded-3xl border border-black/5 bg-white p-6 md:p-8">
-      <h3 class="text-xl md:text-2xl font-semibold text-zinc-900">Aprende de las plagas</h3>
-      <p class="mt-2 text-zinc-700">Consejos prácticos y guías rápidas para tu hogar o negocio.</p>
-      <div class="mt-4 flex flex-wrap gap-3">
-        <a href="/aprende-de-las-plagas" class="btn btn-outline" data-astro-prefetch>Guías y consejos</a>
-        <a href="/politicas" class="btn btn-ghost" data-astro-prefetch>Políticas</a>
-        <a href="/contact" class="btn btn-ghost" data-astro-prefetch>Contacto</a>
+  <section class="pb-20">
+    <div class="container-max">
+      <div class="rounded-3xl border border-emerald-100 bg-emerald-50/80 p-8 md:p-12">
+        <div class="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-between">
+          <div class="max-w-2xl">
+            <p class="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-600">Recursos y soporte</p>
+            <h3 class="mt-3 text-3xl font-semibold text-zinc-900">Aprende, prevén y actúa con respaldo profesional</h3>
+            <p class="mt-4 text-base text-zinc-700">
+              Descubre guías descargables, lineamientos legales y canales de contacto directo con nuestro equipo técnico.
+            </p>
+          </div>
+          <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <a href="/aprende-de-las-plagas" class="btn btn-secondary btn-block" data-astro-prefetch>
+              Guías y consejos
+            </a>
+            <a href="/politicas" class="btn btn-outline btn-block" data-astro-prefetch>
+              Políticas
+            </a>
+            <a href="/contact" class="btn btn-ghost btn-block" data-astro-prefetch>
+              Contacto
+            </a>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add a configurable hero component with support for multiple calls to action, feature bullets, and stats overlays
- redesign the landing page with clearer service copy, sector coverage, benefits, and an updated educational CTA block
- improve the base layout metadata/accessibility and point the header logo at the existing asset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd91e333208327ac44ecd355a5af80