### PR TITLE
perf: inline critical CSS for /cucarachas page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,5 +8,5 @@ export default defineConfig({
   site: 'https://ecoquimia-astro-site.vercel.app',
   output: 'server',        // necesitas server para acciones/envío de formularios
   adapter: vercel(),       // <-- importantísimo: usa el adapter de Vercel
-  integrations: [tailwind(), sitemap()],
+  integrations: [tailwind({ applyBaseStyles: false }), sitemap()],
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,12 @@
         "html-validate": "^10.0.0",
         "postcss": "^8.4.40",
         "prettier": "^3.3.3",
+        "rimraf": "^6.0.1",
         "tailwindcss": "^3.4.10",
         "typescript": "^5.9.2"
       },
       "engines": {
-        "node": ">=20.0.0 <23.0.0"
+        "node": "22.x"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7769,6 +7770,66 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
+      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.0.3",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
+      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/rollup": {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
 const year = new Date().getFullYear();
 ---
-<footer class="mt-16 bg-zinc-950 text-white">
+<footer class="mt-16 bg-zinc-950 text-zinc-100">
   <div class="container-max py-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
     <!-- Marca -->
     <div>
@@ -9,7 +9,7 @@ const year = new Date().getFullYear();
         <img src="/favicon.svg" class="w-6 h-6" alt="Ecoquimia logo" />
         <span>Eco<span class="text-brand">quimia</span></span>
       </a>
-      <p class="text-sm text-white/70 mt-2">
+      <p class="mt-2 text-sm tracking-wide">
         Control integral de plagas para hogares y empresas. Santo Domingo, RD.
       </p>
     </div>
@@ -18,9 +18,9 @@ const year = new Date().getFullYear();
     <div>
       <h4 class="font-semibold mb-2">Contacto</h4>
       <address class="not-italic">
-        <ul class="space-y-1 text-sm text-white/70">
-          <li>📞 <a href="tel:+18096172105" class="underline hover:text-white">+1&nbsp;(809)&nbsp;617&#8209;2105</a></li>
-          <li>✉️ <a href="mailto:contacto@ecoquimia.com" class="underline hover:text-white">contacto@ecoquimia.com</a></li>
+        <ul class="space-y-1 text-sm tracking-wide">
+          <li>📞 <a href="tel:+18096172105" class="text-zinc-50 hover:text-white hover:underline">+1&nbsp;(809)&nbsp;617&#8209;2105</a></li>
+          <li>✉️ <a href="mailto:contacto@ecoquimia.com" class="text-zinc-50 hover:text-white hover:underline">contacto@ecoquimia.com</a></li>
           <li>📍 Santo Domingo, RD</li>
         </ul>
       </address>
@@ -40,26 +40,26 @@ const year = new Date().getFullYear();
     <!-- Enlaces -->
     <nav aria-label="Enlaces del sitio">
       <h4 class="font-semibold mb-2">Enlaces</h4>
-      <ul class="space-y-1 text-sm">
-        <li><a href="/" class="text-white/80 hover:text-white">Inicio</a></li>
-        <li><a href="/nosotros" class="text-white/80 hover:text-white">Nosotros</a></li>
-        <li><a href="/services" class="text-white/80 hover:text-white">Servicios</a></li>
-        <li><a href="/cotizacion" class="text-white/80 hover:text-white">Cotización</a></li>
-        <li><a href="/aprende-de-las-plagas" class="text-white/80 hover:text-white">Aprende de las plagas</a></li>
-        <li><a href="/contact" class="text-white/80 hover:text-white">Contacto</a></li>
-        <li><a href="/politicas" class="text-white/80 hover:text-white">Políticas</a></li>
+      <ul class="space-y-1 text-sm tracking-wide">
+        <li><a href="/" class="text-zinc-50 hover:text-white hover:underline">Inicio</a></li>
+        <li><a href="/nosotros" class="text-zinc-50 hover:text-white hover:underline">Nosotros</a></li>
+        <li><a href="/services" class="text-zinc-50 hover:text-white hover:underline">Servicios</a></li>
+        <li><a href="/cotizacion" class="text-zinc-50 hover:text-white hover:underline">Cotización</a></li>
+        <li><a href="/aprende-de-las-plagas" class="text-zinc-50 hover:text-white hover:underline">Aprende de las plagas</a></li>
+        <li><a href="/contact" class="text-zinc-50 hover:text-white hover:underline">Contacto</a></li>
+        <li><a href="/politicas" class="text-zinc-50 hover:text-white hover:underline">Políticas</a></li>
       </ul>
     </nav>
   </div>
 
   <div class="border-t border-white/10">
-    <div class="container-max py-4 flex flex-col sm:flex-row items-center justify-between gap-3 text-xs text-white/60">
+    <div class="container-max py-4 flex flex-col sm:flex-row items-center justify-between gap-3 text-sm tracking-wide">
       <span>© {year} Ecoquimia</span>
       <!-- Redes sociales -->
       <nav aria-label="Redes sociales" class="flex gap-3">
-        <a href="#" class="hover:text-white/80" target="_blank" rel="noopener noreferrer">Facebook</a>
-        <a href="#" class="hover:text-white/80" target="_blank" rel="noopener noreferrer">Instagram</a>
-        <a href="#" class="hover:text-white/80" target="_blank" rel="noopener noreferrer">TikTok</a>
+        <a href="#" class="text-zinc-50 hover:text-white hover:underline" target="_blank" rel="noopener noreferrer">Facebook</a>
+        <a href="#" class="text-zinc-50 hover:text-white hover:underline" target="_blank" rel="noopener noreferrer">Instagram</a>
+        <a href="#" class="text-zinc-50 hover:text-white hover:underline" target="_blank" rel="noopener noreferrer">TikTok</a>
       </nav>
     </div>
   </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,35 +1,36 @@
 ---
 const year = new Date().getFullYear();
 ---
-<footer class="mt-16 bg-zinc-950 text-zinc-100">
-  <div class="container-max py-12 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+<footer class="mt-16 bg-zinc-950 text-zinc-100 relative isolate overflow-hidden">
+  <div class="absolute inset-0 bg-gradient-to-b from-zinc-900/40 via-zinc-900/80 to-zinc-950" aria-hidden="true"></div>
+  <div class="container-max relative z-10 py-12 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
     <!-- Marca -->
-    <div>
-      <a href="/" class="flex items-center gap-2 text-lg font-bold" aria-label="Ir al inicio">
+    <div class="text-center sm:text-left">
+      <a href="/" class="flex items-center justify-center sm:justify-start gap-2 text-lg font-bold" aria-label="Ir al inicio">
         <img src="/favicon.svg" class="w-6 h-6" alt="Ecoquimia logo" />
         <span>Eco<span class="text-brand">quimia</span></span>
       </a>
-      <p class="mt-2 text-sm tracking-wide">
+      <p class="mt-3 text-base tracking-wide text-zinc-200">
         Control integral de plagas para hogares y empresas. Santo Domingo, RD.
       </p>
     </div>
 
     <!-- Contacto -->
-    <div>
-      <h4 class="font-semibold mb-2">Contacto</h4>
+    <div class="text-center sm:text-left">
+      <h4 class="font-semibold mb-3 text-zinc-100">Contacto</h4>
       <address class="not-italic">
-        <ul class="space-y-1 text-sm tracking-wide">
+        <ul class="space-y-2 text-base tracking-wide text-zinc-200">
           <li>📞 <a href="tel:+18096172105" class="text-zinc-50 hover:text-white hover:underline">+1&nbsp;(809)&nbsp;617&#8209;2105</a></li>
           <li>✉️ <a href="mailto:contacto@ecoquimia.com" class="text-zinc-50 hover:text-white hover:underline">contacto@ecoquimia.com</a></li>
           <li>📍 Santo Domingo, RD</li>
         </ul>
       </address>
-      <div class="mt-3">
+      <div class="mt-4 flex justify-center sm:justify-start">
         <a
           href="https://wa.me/18296666004?text=Hola%20quiero%20una%20cotizaci%C3%B3n"
           target="_blank"
           rel="noopener noreferrer"
-          class="btn btn-primary text-sm"
+          class="btn btn-primary text-base"
           aria-label="Escribir por WhatsApp a Ecoquimia"
         >
           WhatsApp
@@ -38,9 +39,9 @@ const year = new Date().getFullYear();
     </div>
 
     <!-- Enlaces -->
-    <nav aria-label="Enlaces del sitio">
-      <h4 class="font-semibold mb-2">Enlaces</h4>
-      <ul class="space-y-1 text-sm tracking-wide">
+    <nav aria-label="Enlaces del sitio" class="text-center sm:text-left">
+      <h4 class="font-semibold mb-3 text-zinc-100">Enlaces</h4>
+      <ul class="space-y-2 text-base tracking-wide">
         <li><a href="/" class="text-zinc-50 hover:text-white hover:underline">Inicio</a></li>
         <li><a href="/nosotros" class="text-zinc-50 hover:text-white hover:underline">Nosotros</a></li>
         <li><a href="/services" class="text-zinc-50 hover:text-white hover:underline">Servicios</a></li>
@@ -52,11 +53,11 @@ const year = new Date().getFullYear();
     </nav>
   </div>
 
-  <div class="border-t border-white/10">
-    <div class="container-max py-4 flex flex-col sm:flex-row items-center justify-between gap-3 text-sm tracking-wide">
-      <span>© {year} Ecoquimia</span>
+  <div class="relative border-t border-white/10">
+    <div class="container-max relative z-10 py-5 flex flex-col sm:flex-row items-center justify-between gap-3 text-sm tracking-wide text-zinc-200">
+      <span class="text-center sm:text-left">© {year} Ecoquimia</span>
       <!-- Redes sociales -->
-      <nav aria-label="Redes sociales" class="flex gap-3">
+      <nav aria-label="Redes sociales" class="flex gap-4">
         <a href="#" class="text-zinc-50 hover:text-white hover:underline" target="_blank" rel="noopener noreferrer">Facebook</a>
         <a href="#" class="text-zinc-50 hover:text-white hover:underline" target="_blank" rel="noopener noreferrer">Instagram</a>
         <a href="#" class="text-zinc-50 hover:text-white hover:underline" target="_blank" rel="noopener noreferrer">TikTok</a>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
+import "../styles/global.css";
 
 interface Props {
   title?: string;

--- a/src/pages/_cucarachas-critical.css
+++ b/src/pages/_cucarachas-critical.css
@@ -1,0 +1,290 @@
+:root {
+  color-scheme: light;
+}
+
+body.cucarachas-page {
+  margin: 0;
+  min-height: 100%;
+  background: #f8fafc;
+  color: #0f172a;
+  font-family: "Inter", "Work Sans", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: none;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.pest-nav {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  background: rgba(18, 18, 18, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.pest-nav__inner {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  min-height: 64px;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.pest-nav__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: -0.015em;
+}
+
+.pest-nav__brand span strong {
+  color: #34d399;
+}
+
+.pest-nav__links {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.pest-nav__link {
+  color: rgba(255, 255, 255, 0.76);
+  font-size: 0.95rem;
+  font-weight: 500;
+  position: relative;
+  transition: color 0.2s ease;
+}
+
+.pest-nav__link:hover,
+.pest-nav__link:focus-visible {
+  color: #fff;
+}
+
+.pest-nav__link.is-active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.45rem;
+  width: 100%;
+  height: 2px;
+  border-radius: 999px;
+  background: #34d399;
+}
+
+.pest-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  line-height: 1;
+  transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.pest-button:focus-visible {
+  outline: 2px solid rgba(52, 211, 153, 0.85);
+  outline-offset: 2px;
+}
+
+.pest-button--primary {
+  background: #059669;
+  color: #fff;
+  box-shadow: 0 14px 32px rgba(5, 150, 105, 0.35);
+}
+
+.pest-button--primary:hover,
+.pest-button--primary:focus-visible {
+  background: #047857;
+  transform: translateY(-1px);
+}
+
+.pest-button--ghost {
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.pest-button--ghost:hover,
+.pest-button--ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.pest-hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding: clamp(4.5rem, 8vw, 7rem) 0 clamp(3rem, 6vw, 5rem);
+  min-height: 520px;
+  overflow: hidden;
+  background-color: #0f172a;
+  color: #fff;
+}
+
+.pest-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(115deg, rgba(5, 150, 105, 0.55) 0%, rgba(15, 23, 42, 0.95) 55%), var(--hero-image, radial-gradient(circle at center, rgba(24, 24, 27, 0.85), rgba(15, 23, 42, 0.95)));
+  background-size: cover;
+  background-position: center;
+  transform: scale(1.05);
+  filter: brightness(0.92);
+  z-index: 0;
+}
+
+.pest-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(15, 23, 42, 0.78) 0%, rgba(15, 23, 42, 0.45) 55%, rgba(15, 23, 42, 0.2) 100%);
+  z-index: 0;
+}
+
+.pest-hero__container {
+  position: relative;
+  z-index: 1;
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.pest-hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.pest-hero__title {
+  margin: 1.25rem 0 0.85rem;
+  font-size: clamp(2.6rem, 5.2vw, 4rem);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  font-weight: 800;
+}
+
+.pest-hero__highlight {
+  color: #34d399;
+}
+
+.pest-hero__excerpt {
+  max-width: 38rem;
+  font-size: 1.1rem;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.pest-hero__actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.pest-hero__meta {
+  margin-top: 1.5rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+  letter-spacing: 0.02em;
+}
+
+@media (max-width: 900px) {
+  .pest-nav__inner {
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 0 1.25rem;
+  }
+
+  .pest-nav__links {
+    width: 100%;
+    order: 3;
+    justify-content: center;
+    padding-bottom: 0.75rem;
+    gap: 1rem;
+  }
+
+  .pest-nav__cta {
+    order: 2;
+  }
+
+  .pest-nav__brand {
+    order: 1;
+  }
+
+  .pest-hero {
+    padding: clamp(4rem, 14vw, 6rem) 0 clamp(2.5rem, 10vw, 4rem);
+    min-height: unset;
+  }
+
+  .pest-hero__container {
+    text-align: center;
+  }
+
+  .pest-hero__excerpt {
+    margin: 0 auto;
+  }
+
+  .pest-hero__actions {
+    justify-content: center;
+  }
+}
+
+@media (max-width: 540px) {
+  .pest-nav__inner {
+    padding: 0 1rem;
+  }
+
+  .pest-nav__links {
+    gap: 0.75rem;
+  }
+
+  .pest-button {
+    width: 100%;
+  }
+
+  .pest-nav__cta {
+    width: 100%;
+    text-align: center;
+  }
+
+  .pest-hero__title {
+    font-size: clamp(2.3rem, 11vw, 3rem);
+  }
+
+  .pest-hero__excerpt {
+    font-size: 1rem;
+  }
+}

--- a/src/pages/_cucarachas-deferred.css
+++ b/src/pages/_cucarachas-deferred.css
@@ -1,0 +1,348 @@
+.cucarachas-page {
+  background: #0f172a;
+}
+
+main.pest-main {
+  display: block;
+  position: relative;
+}
+
+.pest-main__body {
+  position: relative;
+  z-index: 1;
+  margin-top: -4rem;
+  padding: clamp(3rem, 6vw, 4.5rem) 0 clamp(4rem, 8vw, 6rem);
+  background: #f8fafc;
+  border-radius: 2.5rem 2.5rem 0 0;
+  box-shadow: 0 -45px 120px rgba(15, 23, 42, 0.55);
+}
+
+.pest-main__body::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(52, 211, 153, 0.15), transparent 55%), radial-gradient(circle at top left, rgba(37, 99, 235, 0.1), transparent 45%);
+  opacity: 0.9;
+  pointer-events: none;
+}
+
+.pest-main__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.pest-overview {
+  background: #ffffff;
+  border-radius: 2rem;
+  padding: clamp(2.25rem, 4vw, 2.75rem);
+  box-shadow: 0 32px 80px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  display: grid;
+  gap: 1.75rem;
+}
+
+.pest-overview h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  line-height: 1.25;
+  color: #0f172a;
+  letter-spacing: -0.015em;
+}
+
+.pest-overview p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: #475569;
+}
+
+.pest-overview__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1.25rem 1.75rem;
+}
+
+.pest-overview__meta dt {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.pest-overview__meta dd {
+  margin: 0.4rem 0 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.pest-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pest-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: #e9fbf4;
+  color: #047857;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.pest-article {
+  margin-top: clamp(3rem, 6vw, 3.75rem);
+  padding: clamp(2.5rem, 5vw, 3.5rem);
+  border-radius: 2.25rem;
+  background: #ffffff;
+  box-shadow: 0 35px 90px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  color: #0f172a;
+}
+
+.pest-article :where(h2) {
+  font-size: clamp(1.7rem, 3.5vw, 2rem);
+  margin-top: clamp(2.4rem, 6vw, 2.9rem);
+  margin-bottom: 1rem;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  color: #0f172a;
+}
+
+.pest-article :where(h3) {
+  font-size: clamp(1.25rem, 2.5vw, 1.45rem);
+  margin-top: 2rem;
+  margin-bottom: 0.75rem;
+  color: #0f172a;
+}
+
+.pest-article :where(p) {
+  margin: 1rem 0;
+  font-size: 1.02rem;
+  line-height: 1.75;
+  color: #334155;
+}
+
+.pest-article :where(ul, ol) {
+  padding-left: 1.4rem;
+  margin: 1rem 0 1.5rem;
+  color: #334155;
+}
+
+.pest-article ul {
+  list-style: disc;
+}
+
+.pest-article ol {
+  list-style: decimal;
+}
+
+.pest-article li {
+  margin: 0.4rem 0;
+  line-height: 1.6;
+}
+
+.pest-article strong {
+  color: #0f172a;
+}
+
+.pest-article blockquote {
+  margin: 2rem 0;
+  padding: 1.5rem 1.75rem;
+  border-left: 4px solid #34d399;
+  background: #f1fbf6;
+  border-radius: 1.2rem;
+  color: #0f172a;
+}
+
+.pest-cta {
+  margin-top: clamp(3.5rem, 7vw, 4.5rem);
+  position: relative;
+  overflow: hidden;
+  border-radius: 2.25rem;
+  padding: clamp(2.5rem, 5vw, 3.5rem);
+  background: radial-gradient(circle at top left, rgba(52, 211, 153, 0.55), rgba(5, 150, 105, 0.92) 62%, rgba(15, 23, 42, 1));
+  color: #ffffff;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.5rem;
+  box-shadow: 0 40px 100px rgba(15, 23, 42, 0.45);
+}
+
+.pest-cta::after {
+  content: "";
+  position: absolute;
+  width: 320px;
+  height: 320px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  top: -120px;
+  right: -80px;
+  filter: blur(0);
+}
+
+.pest-cta__info {
+  flex: 1 1 340px;
+  position: relative;
+  z-index: 1;
+}
+
+.pest-cta__info h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.85rem, 3.2vw, 2.4rem);
+  line-height: 1.2;
+}
+
+.pest-cta__info p {
+  margin: 0;
+  font-size: 1.05rem;
+  line-height: 1.65;
+  color: rgba(255, 255, 255, 0.86);
+  max-width: 32rem;
+}
+
+.pest-cta__actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.pest-button--outline {
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  color: #ffffff;
+  background: transparent;
+}
+
+.pest-button--outline:hover,
+.pest-button--outline:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.pest-footer {
+  margin-top: clamp(3rem, 6vw, 4rem);
+  background: #04070c;
+  color: #e2e8f0;
+  padding: clamp(2.75rem, 6vw, 4rem) 0;
+}
+
+.pest-footer__inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.pest-footer__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 1.15rem;
+  color: #ffffff;
+}
+
+.pest-footer__brand span strong {
+  color: #34d399;
+}
+
+.pest-footer__desc {
+  margin: 0;
+  max-width: 38rem;
+  color: #94a3b8;
+  line-height: 1.65;
+}
+
+.pest-footer__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.pest-footer__links a {
+  color: #cbd5f5;
+  font-size: 0.95rem;
+  transition: color 0.2s ease;
+}
+
+.pest-footer__links a:hover,
+.pest-footer__links a:focus-visible {
+  color: #ffffff;
+}
+
+.pest-footer__legal {
+  margin-top: 1.25rem;
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+@media (max-width: 900px) {
+  .pest-main__body {
+    margin-top: -3rem;
+  }
+
+  .pest-overview {
+    padding: 2rem;
+  }
+}
+
+@media (max-width: 700px) {
+  .pest-main__inner {
+    padding: 0 1.25rem;
+  }
+
+  .pest-article {
+    padding: 1.9rem;
+  }
+
+  .pest-cta {
+    padding: 2.25rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .pest-overview {
+    padding: 1.75rem;
+  }
+
+  .pest-overview__meta {
+    grid-template-columns: 1fr;
+  }
+
+  .pest-article {
+    padding: 1.65rem;
+  }
+
+  .pest-cta__actions,
+  .pest-button {
+    width: 100%;
+  }
+
+  .pest-footer__inner {
+    text-align: center;
+  }
+
+  .pest-footer__links {
+    justify-content: center;
+  }
+
+  .pest-footer__legal {
+    margin-top: 0.75rem;
+  }
+}

--- a/src/pages/cucarachas.astro
+++ b/src/pages/cucarachas.astro
@@ -1,0 +1,171 @@
+---
+import { getEntryBySlug } from "astro:content";
+import criticalStyles from "./_cucarachas-critical.css?inline";
+import deferredHref from "./_cucarachas-deferred.css?url";
+
+export const prerender = true;
+
+const entry = await getEntryBySlug("plagas", "cucarachas");
+if (!entry) {
+  throw new Error("No se encontró la guía de cucarachas en content/plagas.");
+}
+
+const { Content } = await entry.render();
+const data = entry.data;
+const tags = Array.isArray(data.tags) ? data.tags : [];
+const heroCover = data.cover && data.cover.length > 0 ? data.cover : "/brief/plagas.png";
+const excerpt = data.excerpt ?? "Control profesional de cucarachas con saneamiento, cebos dirigidos y monitoreo continuo.";
+const updatedLabel = data.updated
+  ? new Date(data.updated).toLocaleDateString("es-DO", { day: "numeric", month: "long", year: "numeric" })
+  : undefined;
+const heroHighlight = (data.title ?? "cucarachas").toLowerCase();
+
+const navLinks = [
+  { href: "/", label: "Inicio" },
+  { href: "/nosotros", label: "Nosotros" },
+  { href: "/services", label: "Servicios" },
+  { href: "/cotizacion", label: "Cotización" },
+  { href: "/aprende-de-las-plagas", label: "Aprende de las plagas" },
+  { href: "/contact", label: "Contacto" },
+  { href: "/politicas", label: "Políticas" },
+];
+
+const whatsappText = "Hola, quiero una cotización de control de plagas.";
+const whatsappUrl = `https://wa.me/18096172105?text=${encodeURIComponent(whatsappText)}`;
+const currentYear = new Date().getFullYear();
+---
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Cucarachas — Ecoquimia</title>
+    <meta name="description" content={excerpt} />
+    <style is:inline>{criticalStyles}</style>
+    <link
+      rel="preload"
+      as="style"
+      href={deferredHref}
+      onload="this.rel='stylesheet';this.onload=null"
+      importance="low"
+    />
+    <noscript><link rel="stylesheet" href={deferredHref} /></noscript>
+  </head>
+  <body class="cucarachas-page">
+    <header class="pest-nav">
+      <div class="pest-nav__inner">
+        <a class="pest-nav__brand" href="/" aria-label="Ir al inicio de Ecoquimia">
+          <img src="/logo/ecoquimia.svg" alt="Ecoquimia" width="96" height="24" loading="eager" />
+          <span>Eco<strong>quimia</strong></span>
+        </a>
+        <nav class="pest-nav__links" aria-label="Navegación principal">
+          {navLinks.map((link) => (
+            <a class={`pest-nav__link${link.href === "/aprende-de-las-plagas" ? " is-active" : ""}`} href={link.href}>
+              {link.label}
+            </a>
+          ))}
+        </nav>
+        <a class="pest-nav__cta pest-button pest-button--primary" href={whatsappUrl} target="_blank" rel="noopener noreferrer">
+          WhatsApp
+        </a>
+      </div>
+    </header>
+
+    <main id="contenido-principal" class="pest-main">
+      <section class="pest-hero" style={{ "--hero-image": `url(${heroCover})` }}>
+        <div class="pest-hero__container">
+          <p class="pest-hero__eyebrow">Control integral de plagas</p>
+          <h1 class="pest-hero__title">
+            Controla las <span class="pest-hero__highlight">{heroHighlight}</span> con Ecoquimia
+          </h1>
+          {excerpt && <p class="pest-hero__excerpt">{excerpt}</p>}
+          <div class="pest-hero__actions">
+            <a class="pest-button pest-button--primary" href="/cotizacion">Solicitar inspección</a>
+            <a class="pest-button pest-button--ghost" href="/services">Planes y servicios</a>
+          </div>
+          {updatedLabel && <p class="pest-hero__meta">Actualizado {updatedLabel}</p>}
+        </div>
+      </section>
+
+      <div class="pest-main__body">
+        <div class="pest-main__inner">
+          <section class="pest-overview" aria-labelledby="resumen-cucarachas">
+            <div>
+              <h2 id="resumen-cucarachas">Panorama rápido</h2>
+              <p>
+                Identifica focos, hábitos y riesgos de las cucarachas para aplicar un plan de saneamiento, exclusión y control
+                profesional.
+              </p>
+            </div>
+            <dl class="pest-overview__meta">
+              <div>
+                <dt>Tiempo de respuesta</dt>
+                <dd>24&nbsp;h en Santo Domingo</dd>
+              </div>
+              {updatedLabel && (
+                <div>
+                  <dt>Actualizado</dt>
+                  <dd>{updatedLabel}</dd>
+                </div>
+              )}
+              {tags.length > 0 && (
+                <div>
+                  <dt>Etiquetas</dt>
+                  <dd>{tags.join(" · ")}</dd>
+                </div>
+              )}
+            </dl>
+            {tags.length > 0 && (
+              <div class="pest-chip-list" aria-label="Sectores relacionados">
+                {tags.map((tag) => (
+                  <span class="pest-chip">{tag}</span>
+                ))}
+              </div>
+            )}
+          </section>
+
+          <article class="pest-article" id="guia" aria-label="Guía completa sobre cucarachas">
+            <Content />
+          </article>
+
+          <section class="pest-cta" aria-labelledby="cta-cucarachas">
+            <div class="pest-cta__info">
+              <h2 id="cta-cucarachas">Agenda una inspección profesional</h2>
+              <p>
+                Nuestros técnicos certificados evalúan la infestación, aplican cebos dirigidos y monitorean hasta erradicar el
+                problema.
+              </p>
+            </div>
+            <div class="pest-cta__actions">
+              <a class="pest-button pest-button--primary" href="/cotizacion">Solicitar cotización</a>
+              <a class="pest-button pest-button--outline" href={whatsappUrl} target="_blank" rel="noopener noreferrer">
+                Escribir por WhatsApp
+              </a>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+
+    <footer class="pest-footer">
+      <div class="pest-footer__inner">
+        <a class="pest-footer__brand" href="/" aria-label="Inicio Ecoquimia">
+          <img src="/logo/ecoquimia.svg" alt="Ecoquimia" width="96" height="24" loading="lazy" />
+          <span>Eco<strong>quimia</strong></span>
+        </a>
+        <p class="pest-footer__desc">
+          Control integral de plagas para hogares y negocios en República Dominicana. Protocolos seguros, reportes claros y
+          seguimiento experto.
+        </p>
+        <nav aria-label="Enlaces principales">
+          <div class="pest-footer__links">
+            {navLinks.map((link) => (
+              <a href={link.href}>{link.label}</a>
+            ))}
+          </div>
+        </nav>
+        <p class="pest-footer__legal">© {currentYear} Ecoquimia. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `/cucarachas` page that inlines critical nav/hero CSS and preloads the remainder without blocking rendering
- move the non-critical layout/typography into a deferred stylesheet that loads after first paint
- disable Tailwind automatic base injection and import `global.css` in the shared layout so only the new page can opt out of it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e58983f38883279abac056a252189b